### PR TITLE
Allow rewriting of NIT table

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,14 @@ then
   AC_DEFINE(TUNE_OLD, 1, Define if you want the old code for tuning)
 fi
 
+AC_ARG_ENABLE(rewrite_nit_support,
+  [ --enable-rewrite_nit_support    Build with rewrite nit support],,[enable_rewrite_nit_support="no"])
+
+if test "${enable_rewrite_nit_support}" = "yes"
+then
+  AC_DEFINE(REWRITE_NIT_SUPPORT, 1, Define if you want to rewrite the NIT Table)
+fi
+
 # Checks for header files.
 AC_HEADER_RESOLV
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdint.h stdlib.h string.h sys/ioctl.h sys/socket.h sys/time.h syslog.h unistd.h values.h])
@@ -218,6 +226,12 @@ fi
 
 if test "${enable_tune_old}" = "yes" ; then
         echo "Build with old tuning code:                         yes"
+fi
+
+if test "${rewrite_nit_support}" != "no" ; then
+        echo "Build with rewrite nit support:                     yes"
+else
+        echo "Build with rewrite nit support:                      no"
 fi
 
 echo ""

--- a/doc/README.asciidoc
+++ b/doc/README.asciidoc
@@ -111,6 +111,7 @@ The `[configure options]` specific to MuMuDVB are:
   --enable-duma           Debbuging DUMA library (default disabled)
   --enable-android        Support for Android (default disabled)
   --disable-dvb-support   Build without Linux DVB-API support, even on systems where the headers are present
+  --enable-rewrite_nit_support Build with rewrite nit support
 ---------------------------------------------------------------------
 
 [NOTE]

--- a/doc/README_CONF.asciidoc
+++ b/doc/README_CONF.asciidoc
@@ -222,7 +222,9 @@ Packets sending parameters
 |rewrite_pmt | Do we rewrite the PMT PID | 0 | 0 or 1 | See README, important if you don't stream all PIDs
 |rewrite_eit sort_eit | Do we rewrite/sort the EIT PID | 0 | 0 or 1 | See README 
 |sdt_force_eit | Do we force the EIT_schedule_flag and EIT_present_following_flag in SDT | 0 | 0 or 1 | Set to 0 if you don't understand
-|rtp_header | Send the stream with the rtp headers (except for HTTP unicast) | 0 | 0 or 1 | 
+|rtp_header | Send the stream with the rtp headers (except for HTTP unicast) | 0 | 0 or 1 |
+|rewrite_nit | Patch certain frequencies in the nit table | 0 | 0 or 1 | see freq_patch and configure options
+|freq_patch | Map the old frequency given as a hexadecimal value to a new frequency. For example `freq_patch=0x03300000->0x07700000` will rewrite the nit entry with the frequency 330MHz to 770MHz| | `%x->%x` | rewrite_nit needs to be enabled
 |==================================================================================================================
 
 Logs parameters

--- a/doc/html/README.html
+++ b/doc/html/README.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 9.0.0rc1" />
+<meta name="generator" content="AsciiDoc 10.1.2" />
 <title>MuMuDVB - README</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -949,7 +949,8 @@ $ make
   --enable-coverage       build for test coverage (default disabled)
   --enable-duma           Debbuging DUMA library (default disabled)
   --enable-android        Support for Android (default disabled)
-  --disable-dvb-support   Build without Linux DVB-API support, even on systems where the headers are present</code></pre>
+  --disable-dvb-support   Build without Linux DVB-API support, even on systems where the headers are present
+  --enable-rewrite_nit_support Build with rewrite nit support</code></pre>
 </div></div>
 <div class="admonitionblock">
 <table><tr>
@@ -1956,7 +1957,7 @@ udp://192.168.2.101:1239</code></pre>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2024-03-23 16:36:54 CET
+ 2025-01-16 13:47:47 CET
 </div>
 </div>
 </body>

--- a/doc/html/README_CONF.html
+++ b/doc/html/README_CONF.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 9.0.0rc1" />
+<meta name="generator" content="AsciiDoc 10.1.2" />
 <title>MuMuDVB - README for the configuration file</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -1445,6 +1445,20 @@ cellspacing="0" cellpadding="4">
 <td align="left" valign="top"><p class="table">0 or 1</p></td>
 <td align="left" valign="top"><p class="table"></p></td>
 </tr>
+<tr>
+<td align="left" valign="top"><p class="table">rewrite_nit</p></td>
+<td align="left" valign="top"><p class="table">Patch certain frequencies in the nit table</p></td>
+<td align="left" valign="top"><p class="table">0</p></td>
+<td align="left" valign="top"><p class="table">0 or 1</p></td>
+<td align="left" valign="top"><p class="table">see freq_patch and configure options</p></td>
+</tr>
+<tr>
+<td align="left" valign="top"><p class="table">freq_patch</p></td>
+<td align="left" valign="top"><p class="table">Map the old frequency given as a hexadecimal value to a new frequency. For example <code>freq_patch=0x03300000-&gt;0x07700000</code> will rewrite the nit entry with the frequency 330MHz to 770MHz</p></td>
+<td align="left" valign="top"><p class="table"></p></td>
+<td align="left" valign="top"><p class="table"><code>%x-&gt;%x</code></p></td>
+<td align="left" valign="top"><p class="table">rewrite_nit needs to be enabled</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -2129,7 +2143,7 @@ TV3                      (0x0321) 01: PCR == V   V 0x006f A 0x0070 (cat) 0x0072 
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2024-03-23 16:36:54 CET
+ 2025-01-16 14:46:57 CET
 </div>
 </div>
 </body>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,7 @@ AM_LDFLAGS =
 bin_PROGRAMS = mumudvb
 mumudvb_SOURCES = autoconf.c crc32.c dvb.h log.c log.h multicast.c mumudvb.h network.h rewrite.h \
 		  rtp.h sap.h ts.h tune.h unicast_http.h autoconf.h dvb.c errors.h \
-		  mumudvb.c mumudvb_mon.c mumudvb_mon.h mumudvb_common.c network.c rewrite_pmt.c rewrite_pat.c rewrite.c rewrite_sdt.c rewrite_eit.c \
+		  mumudvb.c mumudvb_mon.c mumudvb_mon.h mumudvb_common.c network.c rewrite_pmt.c rewrite_pat.c rewrite.c rewrite_sdt.c rewrite_eit.c rewrite_nit.c \
 		  rtp.c sap.c ts.c t2mi.c tune.c unicast_http.c unicast_queue.c unicast_EIT.c autoconf_sdt.c autoconf_atsc.c \
 		  autoconf_pmt.c autoconf_nit.c unicast_clients.c unicast_monit.c mumudvb_channels.c \
 		  autoconf_pat.c autoconf_cat.c hls.c

--- a/src/autoconf_nit.c
+++ b/src/autoconf_nit.c
@@ -143,7 +143,7 @@ int autoconf_read_nit(auto_p_t *auto_p, mumu_chan_p_t *chan_p)
 	buf += network_descriptors_length;
 	nit_mid_t *middle=(nit_mid_t *)buf;
 	int ts_loop_length=HILO(middle->transport_stream_loop_length);
-	buf +=SIZE_NIT_MID;
+	buf += SIZE_NIT_MID;
 	parse_nit_ts_descriptor(buf,ts_loop_length, chan_p->channels, chan_p->number_of_channels, auto_p->transport_stream_id);
 
 
@@ -199,23 +199,26 @@ void parse_nit_ts_descriptor(unsigned char* buf, int ts_descriptors_loop_len, mu
 				break;
 			}
 			//We parse only descriptors with the right transport_stream_id
-			if(pat_tsid==ts_id)
-			{
-				if(descriptor_tag==0x83)
-				{
+			if(pat_tsid==ts_id) {
+				if(descriptor_tag==0x83) {
 					ts_display_lcn_descriptor(log_module, buf);
 					parse_lcn_descriptor(buf, channels, number_of_channels);
-				}
-				else if(descriptor_tag==0x41)
-					ts_display_service_list_descriptor(log_module, buf);
-				else if(descriptor_tag==0x43)
-					ts_display_satellite_delivery_system_descriptor(log_module, buf);
-				else if(descriptor_tag==0x5A)
-					ts_display_terrestrial_delivery_system_descriptor(log_module, buf);
-				else if(descriptor_tag==0x62)
-					ts_display_frequency_list_descriptor(log_module, buf);
-				else
+				} else if(descriptor_tag==0x41) {
+                    ts_display_service_list_descriptor(log_module, buf);
+                } else if(descriptor_tag==0x43) {
+                    ts_display_satellite_delivery_system_descriptor(log_module, buf);
+                } else if(descriptor_tag==0x44) {
+                    log_message(log_module, MSG_FLOOD, " --- NIT TS descriptor --- cable delivery system descriptor "
+                                                       "len %d descriptors_loop_len %d ------------\n",
+                                                       descriptor_len, descriptors_loop_len);
+                    ts_display_cable_delivery_system_descriptor(log_module, buf);
+                } else if(descriptor_tag==0x5A) {
+                    ts_display_terrestrial_delivery_system_descriptor(log_module, buf);
+                } else if(descriptor_tag==0x62) {
+                    ts_display_frequency_list_descriptor(log_module, buf);
+                } else {
 					log_message( log_module, MSG_FLOOD, " --- NIT TS descriptor --- descriptor_tag == 0x%02x len %d descriptors_loop_len %d ------------\n", descriptor_tag, descriptor_len, descriptors_loop_len);
+                }
 			}
 			buf += descriptor_len;
 			descriptors_loop_len -= descriptor_len;

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -27,7 +27,10 @@
  * it contains the precomputed table
  */
 
+#include "crc32.h"
+
 #include <stdint.h>
+#include "ts.h"
 
 /**CRC table for PAT rebuilding, cam support and autoconfiguration*/
 uint32_t crc32_table[256] =
@@ -98,3 +101,34 @@ uint32_t crc32_table[256] =
 	0xbcb4666d, 0xb8757bda, 0xb5365d03, 0xb1f740b4
 };
 
+/**
+ * @brief CRC32 calculation inspired by the xine project
+ * @param data to be hashed
+ * @param len of data
+ * @return CRC32 value of data
+ */
+unsigned long calculateCRC32(const unsigned char *data, int len)
+{
+    // Now we must adjust the CRC32
+    unsigned long crc32 = 0xffffffff;
+    for (int i = 0; i < len; ++i) {
+        crc32 = (crc32 << 8) ^ crc32_table[((crc32 >> 24) ^ data[i]) & 0xff];
+    }
+    return crc32;
+}
+
+/**
+ * @brief Calculates and sets CRC32 for PAT, EIT, SDT, PMT, NIT
+ * @param data pointer to table
+ */
+void setCRC32(unsigned char *data)
+{
+    tbl_h_t *table = (tbl_h_t *)data;
+    int len = 3 + HILO(table->section_length) - 4; // CRC for complete section but CRC (4 Bytes)
+    unsigned long crc32 = calculateCRC32(data, len);
+    // We write the CRC32 to the buffer
+    data[len] = (crc32 >> 24) & 0xff;
+    data[len + 1] = (crc32 >> 16) & 0xff;
+    data[len + 2] = (crc32 >> 8) & 0xff;
+    data[len + 3] = crc32 & 0xff;
+}

--- a/src/crc32.h
+++ b/src/crc32.h
@@ -1,0 +1,12 @@
+#ifndef _CRC32_H
+#define _CRC32_H
+
+#include <stdint.h>
+
+extern uint32_t crc32_table[256];
+
+unsigned long calculateCRC32(const unsigned char *data, int len);
+
+void setCRC32(unsigned char *data);
+
+#endif //_CRC32_H

--- a/src/log.c
+++ b/src/log.c
@@ -989,6 +989,9 @@ void print_info ()
 #ifdef DVBT2
 			"Built with support for DVB-T2.\n"
 #endif
+#ifdef REWRITE_NIT_SUPPORT
+			"Built with rewrite nit support.\n"
+#endif
 #endif
 			"---------\n"
 			"Originally based on dvbstream 0.6 by (C) Dave Chapman 2001-2004\n"

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -504,6 +504,10 @@ int main (int argc, char **argv)
 			if(iRet==-1)
 				exit(ERROR_CONF);
 		}
+		else if((iRet=read_rewrite_nit_config(substring))) {
+			if (iRet==-1)
+				exit(ERROR_CONF);
+		}
 		else if((iRet=read_logging_configuration(&stats_infos, substring))) //Read the line concerning the logging parameters
 		{
 			if(iRet==-1)

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -1647,7 +1647,7 @@ int main (int argc, char **argv)
 			if ((pid == 0x10) && //This is a NIT PID
 				rewrite_vars.rewrite_nit == OPTION_ON) //AND we asked for rewrite
 			{
-
+				nit_rewrite_new_global_packet(actual_ts_packet, &rewrite_vars);
 			}
 #endif // REWRITE_NIT_SUPPORT
 

--- a/src/mumudvb.c
+++ b/src/mumudvb.c
@@ -1636,6 +1636,16 @@ int main (int argc, char **argv)
 			{
 				eit_rewrite_new_global_packet(actual_ts_packet, &rewrite_vars);
 			}
+#ifdef REWRITE_NIT_SUPPORT
+			/******************************************************/
+			//NIT rewrite
+			/******************************************************/
+			if ((pid == 0x10) && //This is a NIT PID
+				rewrite_vars.rewrite_nit == OPTION_ON) //AND we asked for rewrite
+			{
+
+			}
+#endif // REWRITE_NIT_SUPPORT
 
 
 			/******************************************************/

--- a/src/rewrite.c
+++ b/src/rewrite.c
@@ -52,6 +52,8 @@ void init_rewr_v(rewrite_parameters_t *rewr_p)
 				.nit_version = -1,
 				.nit_needs_update = true,
 				.full_nit = NULL,
+				.nit_section_count = 0,
+				.nit_section_array = NULL,
 #endif
 				.rewrite_pmt = OPTION_UNDEFINED,
 				.rewrite_pat = OPTION_UNDEFINED,

--- a/src/rewrite.c
+++ b/src/rewrite.c
@@ -273,3 +273,16 @@ void set_continuity_counter(unsigned char *buf,int continuity_counter)
 	ts_header->continuity_counter=continuity_counter;
 }
 
+bool table_needs_update(char *mod_log_module, const int stored_version, unsigned char *buf) {
+	tbl_h_t *table=(tbl_h_t *)(get_ts_begin(buf));
+
+	if (!table) return false;
+	if (table->current_next_indicator == 0) {
+		return false;
+	}
+	if (table->version_number!=stored_version) {
+		log_message(mod_log_module, MSG_DEBUG,"Need update. stored version : %d, new: %d\n",stored_version,table->version_number);
+		return true;
+	}
+	return false;
+}

--- a/src/rewrite.c
+++ b/src/rewrite.c
@@ -47,6 +47,12 @@ static char *log_module="Rewrite: ";
 void init_rewr_v(rewrite_parameters_t *rewr_p)
 {
 	*rewr_p=(rewrite_parameters_t){
+#ifdef REWRITE_NIT_SUPPORT
+				.rewrite_nit = OPTION_UNDEFINED,
+				.nit_version = -1,
+				.nit_needs_update = true,
+				.full_nit = NULL,
+#endif
 				.rewrite_pmt = OPTION_UNDEFINED,
 				.rewrite_pat = OPTION_UNDEFINED,
 				.pat_version=-1,
@@ -129,7 +135,27 @@ int rewrite_init(rewrite_parameters_t *rewr_p)
 		pthread_mutex_init(&rewr_p->full_eit->packetmutex,NULL);
 	}
 
-return 0;
+#ifdef REWRITE_NIT_SUPPORT
+	/*****************************************************/
+	//NIT rewriting
+	//memory allocation for MPEG2-TS
+	//packet structures
+	/*****************************************************/
+
+	if (rewr_p->rewrite_nit == OPTION_ON) {
+		rewr_p->full_nit = malloc(sizeof(mumudvb_ts_packet_t));
+		if (rewr_p->full_nit == NULL) {
+			log_message(log_module, MSG_ERROR, "Problem with malloc : %s file : %s line %d\n",
+			            strerror(errno), __FILE__, __LINE__);
+			set_interrupted(ERROR_MEMORY << 8);
+			return 1;
+		}
+		memset(rewr_p->full_nit, 0, sizeof(mumudvb_ts_packet_t));   //we clear it
+		pthread_mutex_init(&rewr_p->full_nit->packetmutex, NULL);
+	}
+#endif
+
+	return 0;
 }
 
 
@@ -214,6 +240,20 @@ int read_rewrite_configuration(rewrite_parameters_t *rewrite_vars, char *substri
 		else
 			rewrite_vars->sdt_force_eit = OPTION_OFF;
 	}
+#ifdef REWRITE_NIT_SUPPORT
+	else if (!strcmp (substring, "rewrite_nit"))
+	{
+		substring = strtok (NULL, delimiteurs);
+		if(atoi (substring))
+		{
+			rewrite_vars->rewrite_nit = OPTION_ON;
+			log_message( log_module, MSG_INFO,
+					"You have enabled the NIT Rewriting\n");
+		}
+		else
+			rewrite_vars->rewrite_nit = OPTION_OFF;
+	}
+#endif
 	else
 		return 0; //Nothing concerning rewrite, we return 0 to explore the other possibilities
 

--- a/src/rewrite.h
+++ b/src/rewrite.h
@@ -78,6 +78,16 @@ typedef struct eit_packet_t{
  * This structure contain the parameters needed for rewriting
  */
 typedef struct rewrite_parameters_t{
+#ifdef REWRITE_NIT_SUPPORT
+	/** Do we rewrite the NIT pid */
+	option_status_t rewrite_nit;
+	/** The actual version of the NIT pid */
+	int nit_version;
+	bool nit_needs_update;
+	/** The Complete NIT PID which we are storing */
+	mumudvb_ts_packet_t *full_nit;
+
+#endif
 	/**Do we rewrite the PMT pid ?*/
 	option_status_t rewrite_pmt;
 

--- a/src/rewrite.h
+++ b/src/rewrite.h
@@ -170,4 +170,6 @@ void eit_rewrite_new_channel_packet(unsigned char *ts_packet, rewrite_parameters
 		unicast_parameters_t *unicast_vars, void *scam_vars_v);
 
 int read_rewrite_nit_config(const char *substring);
+
+bool table_needs_update(char *mod_log_module, const int stored_version, unsigned char *buf);
 #endif

--- a/src/rewrite.h
+++ b/src/rewrite.h
@@ -73,6 +73,13 @@ typedef struct eit_packet_t{
 	struct eit_packet_t *next;
 }eit_packet_t;
 
+typedef struct {
+    bool section_ok;
+    size_t rewritten_section_len;
+    size_t original_section_len;
+    unsigned char rewritten_section[1024];
+} nit_section_t;
+
 
 /** @brief the parameters for the rewriting
  * This structure contain the parameters needed for rewriting
@@ -86,7 +93,8 @@ typedef struct rewrite_parameters_t{
 	bool nit_needs_update;
 	/** The Complete NIT PID which we are storing */
 	mumudvb_ts_packet_t *full_nit;
-
+	uint8_t nit_section_count;
+	nit_section_t *nit_section_array;
 #endif
 	/**Do we rewrite the PMT pid ?*/
 	option_status_t rewrite_pmt;

--- a/src/rewrite.h
+++ b/src/rewrite.h
@@ -170,6 +170,7 @@ void eit_rewrite_new_channel_packet(unsigned char *ts_packet, rewrite_parameters
 		unicast_parameters_t *unicast_vars, void *scam_vars_v);
 
 int read_rewrite_nit_config(const char *substring);
+void nit_rewrite_new_global_packet(unsigned char *ts_packet, rewrite_parameters_t *rewrite_vars);
 
 bool table_needs_update(char *mod_log_module, const int stored_version, unsigned char *buf);
 #endif

--- a/src/rewrite.h
+++ b/src/rewrite.h
@@ -161,4 +161,5 @@ void eit_rewrite_new_global_packet(unsigned char *ts_packet, rewrite_parameters_
 void eit_rewrite_new_channel_packet(unsigned char *ts_packet, rewrite_parameters_t *rewrite_vars, mumudvb_channel_t *channel,
 		unicast_parameters_t *unicast_vars, void *scam_vars_v);
 
+int read_rewrite_nit_config(const char *substring);
 #endif

--- a/src/rewrite_nit.c
+++ b/src/rewrite_nit.c
@@ -228,7 +228,7 @@ void rewrite_nit_section(unsigned char *full_nit_section)
 	nit->section_length_hi = (new_section_length >> 8) & 0x0f;
 	nit->section_length_lo = new_section_length & 0xff;
 
-	ts_display_nit(log_module, (unsigned char *)nit);
+	ts_display_nit(log_module, MSG_INFO, (unsigned char *)nit);
 
 	setCRC32(full_nit_section);
 }

--- a/src/rewrite_nit.c
+++ b/src/rewrite_nit.c
@@ -1,0 +1,54 @@
+/**
+ * @file rewrite_nit.c
+ * @brief Patches NIT frequencies
+ * in order to know which programs are actually being broadcast, we need to reference an external
+ * configuration file. This config needs to be provided by the user in the format defined as follows:
+ * for each frequency to be kept:
+ * rewrite_nit=1
+ * freq_patch=0x03300000->0x07700000
+ * freq_patch=0x04500000->0x07780000
+ * freq_patch=0x04660000->0x07860000 # TSID 10000
+ * freq_patch=0x05620000->0x07940000 # TSID 10017
+ *
+ * frequency entries without corresponding new mapping are discarded along with their entries
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "autoconf.h"
+#include "errors.h"
+#include "log.h"
+#include "mumudvb.h"
+#include "rewrite.h"
+#include "ts.h" /* nit_t*/
+
+static char *log_module = "NIT rewrite: ";
+
+
+typedef enum {
+	QAM_NOT_DEFINED, /* 0x0 */
+	QAM16,           /* 0x01 */
+	QAM32,           /* 0x02 */
+	QAM64,           /* 0x03 */
+	QAM128,          /* 0x04 */
+	QAM256,          /* 0x05 */
+	QAM_RESERVED     /* for future use: 0x06 to 0xFF */
+} modrate_t;
+
+
+typedef struct nit_freq_map {
+	uint32_t oldfreq;     /* in MHz, BCD coded */
+	uint32_t newfreq;     /* in MHz, BCD coded */
+	modrate_t modulation; /* QAM modulation */
+	uint32_t symbrate;    /* in kSymb/sec */
+} nit_freq_map_t;
+
+
+
+
+
+
+
+void nit_rewrite_new_global_packet(unsigned char *ts_packet, rewrite_parameters_t *rewrite_vars) { return; }

--- a/src/rewrite_nit.c
+++ b/src/rewrite_nit.c
@@ -355,4 +355,65 @@ void get_nit_packet(const nit_section_t *nit_section_array, int section_number, 
 	get_null_packet(dest);
 }
 
-void nit_rewrite_new_global_packet(unsigned char *ts_packet, rewrite_parameters_t *rewrite_vars) { return; }
+int global_packet_number = -1;
+int global_section_number = -1;
+
+/**
+ * @brief Swapping the NIT packet with a patched packet for every channel
+ * @param ts_packet fresh ts_packet with size 188
+* @param rewrite_vars the parameters for nit rewriting
+ */
+void nit_rewrite_new_global_packet(unsigned char *ts_packet, rewrite_parameters_t *rewrite_vars)
+{
+	unsigned char *get_ts = ts_packet;
+	while (get_ts_packet(get_ts, rewrite_vars->full_nit)) {
+		get_ts = NULL;
+		nit_t *nit = (nit_t *)(rewrite_vars->full_nit->data_full);
+
+		if (nit->current_next_indicator == 0) {
+			log_message(log_module, MSG_DEBUG, "NIT not yet valid, we get a new one (current_next_indicator == 0)");
+			return;
+		}
+		if (table_needs_update(log_module, rewrite_vars->nit_version, ts_packet)) {
+			rewrite_vars->nit_version = nit->version_number;
+
+			rewrite_vars->nit_section_count = nit->last_section_number + 1;
+			if (nit->section_number > rewrite_vars->nit_section_count) {
+				log_message(log_module, MSG_ERROR, "NIT section number out of range.");
+				break;
+			}
+			rewrite_vars->nit_section_array = reallocarray(rewrite_vars->nit_section_array, rewrite_vars->nit_section_count, sizeof(nit_section_t));
+			if (rewrite_vars->nit_section_array == NULL) {
+				log_message(log_module, MSG_ERROR, "Problem with malloc : %s file : %s line %d",
+							strerror(errno), __FILE__, __LINE__);
+				set_interrupted(ERROR_MEMORY << 8);
+				return;
+			}
+			for (int i = 0; i < rewrite_vars->nit_section_count; ++i) {
+				rewrite_vars->nit_section_array[i].section_ok = false;
+				rewrite_vars->nit_section_array[i].original_section_len = 0;
+				rewrite_vars->nit_section_array[i].rewritten_section_len = 0;
+			}
+		}
+		save_nit_section(rewrite_vars, rewrite_vars->full_nit->data_full);
+	}
+
+
+	ts_header_t *ts_header = (ts_header_t *)ts_packet;
+	bool new_section = ts_header->payload_unit_start_indicator == 1;
+
+	global_packet_number++;
+
+	if (new_section) {
+		nit_t *nit_header = (nit_t *)(ts_packet + NIT_TS_HEADER_LEN + 1);
+		global_section_number = nit_header->section_number;
+		global_packet_number = 0;
+	}
+
+	unsigned char dest[TS_PACKET_SIZE];
+	get_nit_packet(rewrite_vars->nit_section_array, global_section_number, global_packet_number, dest);
+
+	log_message(log_module, MSG_FLOOD, "global section number: %d, global packet number: %d", global_section_number,
+	            global_packet_number);
+	memcpy(ts_packet, dest, TS_PACKET_SIZE);
+}

--- a/src/rewrite_nit.c
+++ b/src/rewrite_nit.c
@@ -46,9 +46,63 @@ typedef struct nit_freq_map {
 } nit_freq_map_t;
 
 
+nit_freq_map_t *freq_map = NULL;
+size_t frequency_cnt = 0;
 
 
+/**
+ * @brief Read a line of the configuration file to check if there is a rewrite nit parameter
+ * @details Sets the frequency map for the rewrite nit module
+ * @param substring The current line
+ * @return -1 on error, 0 on success
+ */
+int read_rewrite_nit_config(const char *substring)
+{
+	if (!strcmp(substring, "freq_patch")) {
+		substring = strtok(NULL, "=");
+		if (substring == NULL) {
+			return -1;
+		}
+		uint32_t old_freq = 0;
+		uint32_t new_freq = 0;
+		char *endptr = NULL;
+		errno = 0;
+		old_freq = strtoul(substring, &endptr, 16);
+		if (errno != 0) {
+			log_message(log_module, MSG_ERROR, "Invalid config: %s", strerror(errno));
+			return -1;
+		}
+		if (*endptr != '-' || *(endptr+1) != '>') {
+			return -1;
+		}
+		endptr += 2;
 
+		errno = 0;
+		new_freq = strtoul(endptr, &endptr, 16);
+		if (errno != 0) {
+			log_message(log_module, MSG_ERROR, "Invalid config: %s", strerror(errno));
+			return -1;
+		}
+
+		if (old_freq == 0 || new_freq == 0) {
+			log_message(log_module, MSG_ERROR, "Missing config frequency");
+			return -1;
+		}
+
+		frequency_cnt++;
+		freq_map = reallocarray(freq_map, frequency_cnt, sizeof(nit_freq_map_t));
+		if (freq_map == NULL) {
+			return -1;
+		}
+		freq_map[frequency_cnt - 1].oldfreq = old_freq;
+		freq_map[frequency_cnt - 1].newfreq = new_freq;
+		log_message(log_module, MSG_INFO, "Added frequency patch: old: 0x%08x new: 0x%08x", old_freq, new_freq);
+
+	} else {
+		return 0;
+	}
+	return 1;
+}
 
 
 void nit_rewrite_new_global_packet(unsigned char *ts_packet, rewrite_parameters_t *rewrite_vars) { return; }

--- a/src/rewrite_nit.c
+++ b/src/rewrite_nit.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include "autoconf.h"
+#include "crc32.h"
 #include "errors.h"
 #include "log.h"
 #include "mumudvb.h"
@@ -102,6 +103,134 @@ int read_rewrite_nit_config(const char *substring)
 		return 0;
 	}
 	return 1;
+}
+
+ts_header_t nit_ts_header =  {
+	.sync_byte = TS_SYNC_BYTE,
+	.transport_error_indicator = 0,
+	.payload_unit_start_indicator = 0,
+	.transport_priority = 0,
+	.pid_hi = 0x0010 >> 8,
+	.pid_lo = 0x0010,
+	.transport_scrambling_control = 0,
+	.adaptation_field_control = 0b01
+};
+
+#define NIT_TS_HEADER_LEN 4
+
+const ts_header_t NULL_TS_HEADER = {
+	.sync_byte = TS_SYNC_BYTE,
+	.transport_error_indicator = 0,
+	.payload_unit_start_indicator = 0,
+	.transport_priority = 0,
+	.pid_hi = 0x1FFF >> 8,
+	.pid_lo = 0x1FFFF & 0x00FF,
+	.transport_scrambling_control = 0,
+	.adaptation_field_control = 0b01
+};
+
+/**
+ * @brief Rewrites frequencies according to @c freq_map
+ * @param cable_descriptor @c cable_delivery_system_descriptor that should be rewritten
+ * @return 1 on rewrite
+ * @return 0 if freq was not rewritten
+ */
+int rewrite_cable_delivery_system_descriptor(descr_cable_delivery_t *cable_descriptor)
+{
+	uint32_t freq = (cable_descriptor->frequency_4 << 24) + (cable_descriptor->frequency_3 << 16)
+	                + (cable_descriptor->frequency_2 << 8) + cable_descriptor->frequency_1;
+
+	for (size_t i = 0; i < frequency_cnt; ++i) {
+		if (freq_map[i].oldfreq == freq) {
+			cable_descriptor->frequency_4 = freq_map[i].newfreq >> 24;
+			cable_descriptor->frequency_3 = freq_map[i].newfreq >> 16;
+			cable_descriptor->frequency_2 = freq_map[i].newfreq >> 8;
+			cable_descriptor->frequency_1 = freq_map[i].newfreq & 0xFF;
+			log_message(log_module, MSG_DEBUG, "Patched freq %x with new freq %x", freq,
+			            freq_map[i].newfreq);
+			return 1;
+		}
+	}
+	return 0;
+}
+
+/**
+ * @brief Iterates through all transport streams and rewrites the frequencies
+ * @note only @c cable_delivery_system_descriptor are patched for now
+ * @param ts_stream pointer to the first transport stream
+ * @param stream_loop_len @c transport_stream_loop_length
+ * @return the number of removed transport streams in bytes
+ */
+size_t rewrite_transport_stream(unsigned char *ts_stream, size_t stream_loop_len)
+{
+	if (stream_loop_len == 0) {
+		log_message(log_module, MSG_FLOOD, "- transport stream loop len is 0");
+		return 0;
+	}
+	size_t removed_bytes = 0;
+
+	while (stream_loop_len > 0) {
+		int descriptors_loop_length = HILO(((nit_ts_t *)ts_stream)->transport_descriptors_length);
+
+		size_t stream_length = NIT_TS_LEN + descriptors_loop_length;
+
+		if (descriptors_loop_length == 0) break;
+		descr_cable_delivery_t *descriptor = (descr_cable_delivery_t *)(ts_stream + NIT_TS_LEN);
+
+		bool remove_stream = 0;
+		while (descriptors_loop_length > 0) {
+			switch (descriptor->descriptor_tag) {
+			case 0x44:
+				remove_stream = rewrite_cable_delivery_system_descriptor(descriptor) == 0;
+				break;
+			default:
+				log_message(log_module, MSG_FLOOD,
+				            "- did not rewrite transport stream descriptor with tag: 0x%x",
+				            descriptor->descriptor_tag);
+				break;
+			}
+			// descriptor length is data length + length(tag + len)
+			descriptor += descriptor->descriptor_length + 2;
+			descriptors_loop_length -= (descriptor->descriptor_length + 2);
+		}
+		stream_loop_len -= stream_length;
+		size_t rest_len = stream_loop_len + 4; // rest of loop + CRC
+
+		if (remove_stream) {
+			log_message(log_module, MSG_DEBUG, "Removed redundant stream from NIT");
+			memmove(ts_stream, ts_stream + stream_length, rest_len);
+			removed_bytes += stream_length;
+		} else {
+			ts_stream += stream_length;
+		}
+	}
+	return removed_bytes;
+}
+
+/**
+ * @brief Rewrites frequencies in a nit section according to @c freq_map
+ * @note only @c cable_delivery_system_descriptor are patched for now
+ * @param full_nit_section pointer to the start of a nit section
+ */
+void rewrite_nit_section(unsigned char *full_nit_section)
+{
+	nit_t *nit = (nit_t *)full_nit_section;
+	nit_mid_t *nit_mid = (nit_mid_t *)(full_nit_section + NIT_LEN + HILO(nit->network_descriptor_length));
+
+	size_t removed_bytes = rewrite_transport_stream((unsigned char *)nit_mid + SIZE_NIT_MID,
+	                         HILO(nit_mid->transport_stream_loop_length));
+	// adjust transport stream loop length and section length
+	size_t new_ts_loop_length = HILO(nit_mid->transport_stream_loop_length) - removed_bytes;
+	nit_mid->transport_stream_loop_length_hi = (new_ts_loop_length >> 8) & 0x0f;
+	nit_mid->transport_stream_loop_length_lo = new_ts_loop_length & 0xff;
+
+	size_t new_section_length = HILO(nit->section_length) - removed_bytes;
+	nit->section_length_hi = (new_section_length >> 8) & 0x0f;
+	nit->section_length_lo = new_section_length & 0xff;
+
+	ts_display_nit(log_module, (unsigned char *)nit);
+
+	setCRC32(full_nit_section);
 }
 
 

--- a/src/rewrite_nit.c
+++ b/src/rewrite_nit.c
@@ -275,4 +275,84 @@ void save_nit_section(rewrite_parameters_t *rewr_p, unsigned char *full_nit_sect
 	}
 }
 
+/**
+ * @brief Writes a NULL packet to @c dest
+ */
+void get_null_packet(unsigned char *dest)
+{
+	memcpy(dest, &NULL_TS_HEADER, NIT_TS_HEADER_LEN);
+	char null_message[] = "INCOMPLETE NIT";
+	strcpy((char *)(dest + NIT_TS_HEADER_LEN), null_message);
+	memset(dest + NIT_TS_HEADER_LEN + strlen(null_message), 0xFF,
+	       TS_PACKET_SIZE - NIT_TS_HEADER_LEN - strlen(null_message));
+}
+
+/**
+ * @brief Writes a rewritten nit packet to dest or a NULL packet if none available
+ * @param section source for selected cached nit section
+ * @param packet_number current index in section
+ * @param dest destination for rewritten nit packet
+ */
+void get_cached_packet(const nit_section_t *section, int packet_number, unsigned char *dest)
+{
+	// the first time 1 byte less is copied
+	int bytes_copied = packet_number * (TS_PACKET_SIZE - NIT_TS_HEADER_LEN) - 1;
+	bytes_copied = bytes_copied < 0 ? 0 : bytes_copied;
+	size_t rest_len = TS_PACKET_SIZE;
+
+	// ts stream is corrupted: no new section was announced
+	if ((unsigned int)bytes_copied >= section->original_section_len) {
+		get_null_packet(dest);
+		log_message(log_module, MSG_WARN, "NIT TS input was corrupted, resyncing at next section\n"
+									"Requested: %d/%lu", bytes_copied, section->original_section_len);
+		return;
+	}
+	// stuff to original size
+	if ((unsigned int)bytes_copied >= section->rewritten_section_len) {
+		get_null_packet(dest);
+		return;
+	}
+
+	ts_header_t *dest_header = (ts_header_t *)dest;
+	memcpy(dest, &nit_ts_header, NIT_TS_HEADER_LEN);
+	rest_len -= NIT_TS_HEADER_LEN;
+	nit_ts_header.continuity_counter = (nit_ts_header.continuity_counter + 1) % 16;
+
+	if (packet_number == 0) {              // this is the first packet, so pointer field is necessary
+		dest[NIT_TS_HEADER_LEN] = 0;   // ISO 13818.1 2.4.4.2 Semantics definition of fields in pointer syntax
+		dest_header->payload_unit_start_indicator = 1;
+		rest_len--;
+	}
+
+	size_t bytes_left = section->rewritten_section_len - bytes_copied;
+
+	if (bytes_left >= rest_len) {
+		memcpy(dest + (TS_PACKET_SIZE - rest_len), section->rewritten_section + bytes_copied, rest_len);
+	} else {
+		memcpy(dest + (TS_PACKET_SIZE - rest_len), section->rewritten_section + bytes_copied,
+		       bytes_left);
+		memset(dest + (TS_PACKET_SIZE - rest_len) + bytes_left, 0xFF, rest_len - bytes_left);
+	}
+}
+
+/**
+ * @brief Writes a rewritten nit packet to dest or a NULL packet if none available
+ * @param nit_section_array source for cached nit sections
+ * @param section_number current section number
+ * @param packet_number current index in section
+ * @param dest destination for rewritten nit packet
+ */
+void get_nit_packet(const nit_section_t *nit_section_array, int section_number, int packet_number, unsigned char *dest)
+{
+	if (nit_section_array != NULL) {
+		const nit_section_t *current_nit_section = &nit_section_array[section_number];
+		if (current_nit_section != NULL && current_nit_section->section_ok) {
+			get_cached_packet(current_nit_section, packet_number, dest);
+			return;
+		}
+	}
+	log_message(log_module, MSG_DEBUG, "No cached packet available for section %d", section_number);
+	get_null_packet(dest);
+}
+
 void nit_rewrite_new_global_packet(unsigned char *ts_packet, rewrite_parameters_t *rewrite_vars) { return; }

--- a/src/rewrite_nit.c
+++ b/src/rewrite_nit.c
@@ -233,5 +233,46 @@ void rewrite_nit_section(unsigned char *full_nit_section)
 	setCRC32(full_nit_section);
 }
 
+/**
+ * @brief Caches the current nit section
+ * @param rewr_p the parameters for nit rewriting
+ * @param full_nit_section section that should be rewritten
+ */
+void save_nit_section(rewrite_parameters_t *rewr_p, unsigned char *full_nit_section)
+{
+	nit_t *nit = (nit_t *)full_nit_section;
+	if (rewr_p->nit_section_array[nit->section_number].section_ok == true) {
+		return;
+	}
+
+	unsigned char *dest = rewr_p->nit_section_array[nit->section_number].rewritten_section;
+
+	if (rewr_p->full_nit->len_full > 1024) {
+		log_message(log_module, MSG_ERROR, "len_full: %d", rewr_p->full_nit->len_full);
+		log_message(log_module, MSG_ERROR, "section_len: %d", HILO(nit->section_length) + 3);
+		return;
+	}
+	memcpy(dest, full_nit_section, HILO(nit->section_length) + 3);
+	rewr_p->nit_section_array[nit->section_number].original_section_len = HILO(nit->section_length) + 3;
+	rewrite_nit_section(dest);
+	rewr_p->nit_section_array[nit->section_number].section_ok = true;
+	rewr_p->nit_section_array[nit->section_number].rewritten_section_len = HILO(((nit_t *)dest)->section_length) + 3;
+	log_message(log_module, MSG_INFO, "NIT section %d is cached", nit->section_number);
+	bool all_cached = true;
+	for (int i = 0; i <= nit->last_section_number; ++i) {
+		if (i > rewr_p->nit_section_count) {
+			log_message(log_module, MSG_ERROR, "NIT section_number is corrupted");
+			break;
+		}
+		if (!rewr_p->nit_section_array[i].section_ok) {
+			all_cached = false;
+			break;
+		}
+	}
+	if (all_cached) {
+		log_message(log_module, MSG_INFO, "All NIT sections are cached");
+		if (frequency_cnt == 0) log_message(log_module, MSG_WARN, "No frequencies kept. See config->freq_patch");
+	}
+}
 
 void nit_rewrite_new_global_packet(unsigned char *ts_packet, rewrite_parameters_t *rewrite_vars) { return; }

--- a/src/ts.c
+++ b/src/ts.c
@@ -677,11 +677,11 @@ void ts_display_pat(char* log_module,unsigned char *buf)
  * @param buf The buffer containing the NIT
  * @attention not the whole NIT is printed (network descriptors) because of the amount of some descriptors
  */
-void ts_display_nit(char *mod_log_module, unsigned char *buf)
+void ts_display_nit(char *mod_log_module, int type, unsigned char *buf)
 {
     nit_t *nit = (nit_t*)(buf);
-    log_message( mod_log_module, MSG_FLOOD,"-------------- Display NIT ----------------");
-    log_message( mod_log_module, MSG_FLOOD,  "network id 0x%04x section_length %d version %i "
+    log_message( mod_log_module, type,"-------------- Display NIT ----------------");
+    log_message( mod_log_module, type,  "network id 0x%04x section_length %d version %i "
                                              "section_number %d last_section_number %d current_next_indicator %d",
                  HILO(nit->network_id),
                  HILO(nit->section_length),
@@ -691,19 +691,19 @@ void ts_display_nit(char *mod_log_module, unsigned char *buf)
                  nit->current_next_indicator);
 
     if(nit->current_next_indicator == 0) {
-        log_message( mod_log_module, MSG_FLOOD,"The current_next_indicator is set to 0, "
+        log_message( mod_log_module, type,"The current_next_indicator is set to 0, "
                                                "this NIT is not valid for the current stream");
     }
 
 
     // network descriptors
-    log_message(mod_log_module, MSG_FLOOD, "network descriptor length: %d",
+    log_message(mod_log_module, type, "network descriptor length: %d",
                 HILO(nit->network_descriptor_length));
 
     nit_mid_t *nit_mid = (nit_mid_t *)((unsigned char *)nit + NIT_LEN + HILO(nit->network_descriptor_length));
 
     // transport descriptors
-    log_message(mod_log_module, MSG_FLOOD, "transport stream loop length: %d",
+    log_message(mod_log_module, type, "transport stream loop length: %d",
                 HILO(nit_mid->transport_stream_loop_length));
     char * tab_log_module = calloc(1, strlen(mod_log_module) + 2 + 1);
     strcpy(tab_log_module, mod_log_module);
@@ -711,7 +711,7 @@ void ts_display_nit(char *mod_log_module, unsigned char *buf)
     ts_display_nit_transport_stream_loop(tab_log_module, (unsigned char *)nit_mid + SIZE_NIT_MID,
                                          HILO(nit_mid->transport_stream_loop_length));
 
-    log_message( mod_log_module, MSG_FLOOD,"-------------- NIT Displayed ----------------");
+    log_message( mod_log_module, type,"-------------- NIT Displayed ----------------");
 }
 
 

--- a/src/ts.c
+++ b/src/ts.c
@@ -667,8 +667,51 @@ void ts_display_pat(char* log_module,unsigned char *buf)
 	}
 	log_message( log_module, MSG_DEBUG,"This PAT contains %d services\n",number_of_services);
 	log_message( log_module, MSG_FLOOD,"-------------- PAT Displayed ----------------\n");
+}
 
 
+/** @brief Display the NIT contents
+ *
+ * @param mod_log_module The log module of the calling function
+ * @param type: message type MSG_*
+ * @param buf The buffer containing the NIT
+ * @attention not the whole NIT is printed (network descriptors) because of the amount of some descriptors
+ */
+void ts_display_nit(char *mod_log_module, unsigned char *buf)
+{
+    nit_t *nit = (nit_t*)(buf);
+    log_message( mod_log_module, MSG_FLOOD,"-------------- Display NIT ----------------");
+    log_message( mod_log_module, MSG_FLOOD,  "network id 0x%04x section_length %d version %i "
+                                             "section_number %d last_section_number %d current_next_indicator %d",
+                 HILO(nit->network_id),
+                 HILO(nit->section_length),
+                 nit->version_number,
+                 nit->section_number,
+                 nit->last_section_number,
+                 nit->current_next_indicator);
+
+    if(nit->current_next_indicator == 0) {
+        log_message( mod_log_module, MSG_FLOOD,"The current_next_indicator is set to 0, "
+                                               "this NIT is not valid for the current stream");
+    }
+
+
+    // network descriptors
+    log_message(mod_log_module, MSG_FLOOD, "network descriptor length: %d",
+                HILO(nit->network_descriptor_length));
+
+    nit_mid_t *nit_mid = (nit_mid_t *)((unsigned char *)nit + NIT_LEN + HILO(nit->network_descriptor_length));
+
+    // transport descriptors
+    log_message(mod_log_module, MSG_FLOOD, "transport stream loop length: %d",
+                HILO(nit_mid->transport_stream_loop_length));
+    char * tab_log_module = calloc(1, strlen(mod_log_module) + 2 + 1);
+    strcpy(tab_log_module, mod_log_module);
+    strcat(tab_log_module, "\t");
+    ts_display_nit_transport_stream_loop(tab_log_module, (unsigned char *)nit_mid + SIZE_NIT_MID,
+                                         HILO(nit_mid->transport_stream_loop_length));
+
+    log_message( mod_log_module, MSG_FLOOD,"-------------- NIT Displayed ----------------");
 }
 
 
@@ -709,11 +752,11 @@ void ts_display_country_avaibility_descriptor(char* log_module,unsigned char *bu
 
 /** @brief show the NIT Network descriptors
  * Loop over the NIT descriptors and call other parsing functions if necessary
+ * @param mod_log_module The log module of the calling function
  * @param buf the buffer containing the descriptors
  * @param descriptors_loop_len the len of buffer containing the descriptors
- * @param service the associated service
  */
-void ts_display_nit_network_descriptors(char* log_module,unsigned char *buf,int descriptors_loop_len)
+void ts_display_nit_network_descriptors(char *mod_log_module,unsigned char *buf,int descriptors_loop_len)
 {
 
 	while (descriptors_loop_len > 0)
@@ -723,17 +766,17 @@ void ts_display_nit_network_descriptors(char* log_module,unsigned char *buf,int 
 
 		if (!descriptor_len)
 		{
-			log_message( log_module, MSG_FLOOD, " --- NIT descriptor --- descriptor_tag == 0x%02x, len is 0\n", descriptor_tag);
+			log_message( mod_log_module, MSG_FLOOD, " --- NIT descriptor --- descriptor_tag == 0x%02x, len is 0\n", descriptor_tag);
 			break;
 		}
 
 		//The service descriptor provides the names of the service provider and the service in text form together with the service_type.
 		if(descriptor_tag==0x40)
-			ts_display_network_name_descriptor(log_module,buf);
+			ts_display_network_name_descriptor(mod_log_module,buf);
 		else if(descriptor_tag==0x5B)
-			ts_display_multilingual_network_name_descriptor(log_module,buf);
+			ts_display_multilingual_network_name_descriptor(mod_log_module,buf);
 		else
-			log_message( log_module, MSG_FLOOD, "NIT network descriptor_tag : 0x%2x\n", descriptor_tag);
+			log_message( mod_log_module, MSG_FLOOD, "NIT network descriptor_tag : 0x%2x\n", descriptor_tag);
 
 		buf += descriptor_len;
 		descriptors_loop_len -= descriptor_len;
@@ -819,6 +862,67 @@ void ts_display_multilingual_network_name_descriptor(char *log_module, unsigned 
 }
 
 
+/** @brief display the NIT transport stream loop
+ * @details Loops over the NIT transport stream loop and calls other parsing functions if necessary
+ * @param mod_log_module The log module of the calling function
+ * @param buf the buffer containing the streams
+ * @param stream_loop_len the len of buffer containing the streams
+ * @attention service list descriptors are commented out because of their amount
+ */
+void ts_display_nit_transport_stream_loop(char *mod_log_module, unsigned char *buf, int stream_loop_len) {
+    if (stream_loop_len == 0) {
+        log_message(mod_log_module, MSG_FLOOD, " --- NIT transport stream loop --- len is 0");
+        return;
+    }
+
+    char * tab_log_module = calloc(1, strlen(mod_log_module) + 2 + 1);
+    strcpy(tab_log_module, mod_log_module);
+    strcat(tab_log_module, "\t");
+
+    while (stream_loop_len > 0) {
+        nit_ts_t *stream = (nit_ts_t *) buf; // Pointer to current transport stream
+
+        log_message(mod_log_module, MSG_FLOOD, "--- NIT transport stream ---");
+        log_message(mod_log_module, MSG_FLOOD, "transport stream id: 0x%x", HILO(stream->transport_stream_id));
+        log_message(mod_log_module, MSG_FLOOD, "original network id: 0x%x", HILO(stream->original_network_id));
+        int descriptors_loop_length = HILO(stream->transport_descriptors_length);
+        log_message(mod_log_module, MSG_FLOOD, "transport stream length: %d", descriptors_loop_length);
+
+        buf += NIT_TS_LEN;
+
+        if (descriptors_loop_length == 0) break;
+        unsigned char *descr = buf;
+
+        while (descriptors_loop_length > 0) {
+            unsigned char descr_tag = descr[0];
+            unsigned char descr_len = descr[1];
+
+            switch (descr_tag) {
+//                case 0x41:
+//                    ts_display_service_list_descriptor(mod_log_module, descr);
+//                    break;
+                case 0x43:
+                    ts_display_satellite_delivery_system_descriptor(tab_log_module, descr);
+                    break;
+                case 0x44:
+                    ts_display_cable_delivery_system_descriptor(tab_log_module, descr);
+                    break;
+                case 0x5a:
+                    ts_display_terrestrial_delivery_system_descriptor(tab_log_module, descr);
+                    break;
+                default:
+                    log_message(tab_log_module, MSG_FLOOD, "--- NIT stream descriptor --- tag: 0x%x", descr_tag);
+            		break;
+            }
+            
+            descr += descr_len + 2; // descriptor length is data length + length(tag + len)
+            descriptors_loop_length -= (descr_len + 2);
+        }
+
+        buf += HILO(stream->transport_descriptors_length);
+        stream_loop_len -= (HILO(stream->transport_descriptors_length) + NIT_TS_LEN);
+    }
+}
 
 /**
  */
@@ -973,6 +1077,56 @@ void ts_display_satellite_delivery_system_descriptor(char* log_module, unsigned 
 		break;
 	}
 	log_message( log_module, MSG_FLOOD, "--- descriptor done ---\n");
+}
+
+
+/** @brief display the contents of cable_delivery_system_descriptor
+ * @cite EN 300 468 V1.16.1   6.2.13.1 Cable delivery system descriptor
+ * @param mod_log_module The log module of the calling function
+ * @param buf the buffer containing the descriptor
+ */
+void ts_display_cable_delivery_system_descriptor(char *mod_log_module, unsigned char *buf) {
+	descr_cable_delivery_t *descr = (descr_cable_delivery_t *) buf;
+
+    log_message( mod_log_module, MSG_FLOOD, "--- NIT stream descriptor --- cable delivery system descriptor\n");
+
+    log_message( mod_log_module, MSG_FLOOD, "Frequency: %x%02x.%02x%02x MHz", descr->frequency_4,
+                 descr->frequency_3, descr->frequency_2, descr->frequency_1);
+
+	log_message( mod_log_module, MSG_FLOOD, "Outer FEC scheme: %d", descr->FEC_outer);
+
+	switch(descr->modulation_type) {
+		case 0:
+			log_message( mod_log_module, MSG_FLOOD, "Not defined");
+			break;
+		case 1:
+			log_message( mod_log_module, MSG_FLOOD, "16-QAM");
+			break;
+		case 2:
+			log_message( mod_log_module, MSG_FLOOD, "32-QAM");
+			break;
+		case 3:
+			log_message( mod_log_module, MSG_FLOOD, "64-QAM");
+			break;
+		case 4:
+			log_message( mod_log_module, MSG_FLOOD, "128-QAM");
+			break;
+		case 5:
+			log_message( mod_log_module, MSG_FLOOD, "256-QAM");
+			break;
+		default:
+			log_message( mod_log_module, MSG_FLOOD, "Reserved");
+			break;
+	}
+
+    log_message( mod_log_module, MSG_FLOOD, "Symbol rate: %d%d%d,%d%d%d%d Msymbol/s",
+         BCDHI(descr->symbol_rate_12), BCDLO(descr->symbol_rate_12), BCDHI(descr->symbol_rate_34),
+         BCDLO(descr->symbol_rate_34), BCDHI(descr->symbol_rate_56), BCDLO(descr->symbol_rate_56),
+         BCDLO(descr->symbol_rate_7) );
+
+	log_message(mod_log_module, MSG_FLOOD, "Inner FEC scheme: %d", descr->FEC_inner);
+
+    log_message( mod_log_module, MSG_FLOOD, "--- descriptor done ---\n");
 }
 
 

--- a/src/ts.h
+++ b/src/ts.h
@@ -901,7 +901,7 @@ struct mumudvb_channel_t;
 void ts_display_pat(char* log_module,unsigned char *buf);
 void ts_display_country_avaibility_descriptor(char* log_module,unsigned char *buf);
 
-void ts_display_nit(char* mod_log_module,unsigned char *buf);
+void ts_display_nit(char* mod_log_module,int type, unsigned char *buf);
 void ts_display_nit_network_descriptors(char *log_module, unsigned char *buf,int descriptors_loop_len);
 void ts_display_network_name_descriptor(char* log_module, unsigned char *buf);
 void ts_display_multilingual_network_name_descriptor(char* log_module, unsigned char *buf);

--- a/src/ts.h
+++ b/src/ts.h
@@ -480,9 +480,11 @@ typedef struct {
 #ifdef __BIG_ENDIAN__
    uint8_t section_syntax_indicator               :1;
    uint8_t                                        :3;
-   uint8_t section_length_hi                      :4;
+   uint8_t section_length_zero                    :2;
+   uint8_t section_length_hi                      :2;
 #else
-   uint8_t section_length_hi                      :4;
+   uint8_t section_length_hi                      :2;
+   uint8_t section_length_zero                    :2;
    uint8_t                                        :3;
    uint8_t section_syntax_indicator               :1;
 #endif

--- a/src/ts.h
+++ b/src/ts.h
@@ -676,6 +676,34 @@ typedef struct {
 #endif
 } descr_sat_delivery_t;
 
+/** @brief 0x44 cable_delivery_system_descriptor */
+typedef struct {
+  uint8_t descriptor_tag                         :8;
+  uint8_t descriptor_length                      :8;
+  uint8_t frequency_4                            :8;
+  uint8_t frequency_3                            :8;
+  uint8_t frequency_2                            :8;
+  uint8_t frequency_1                            :8;
+  uint8_t reserved_future_use_1                  :8;
+#ifdef __BIG_ENDIAN__
+  uint8_t reserved_future_use_2                  :4;
+  uint8_t FEC_outer                              :4;
+#else
+  uint8_t FEC_outer                              :4;
+  uint8_t reserved_future_use_2                  :4;
+#endif
+  uint8_t modulation_type                        :8;
+  uint8_t symbol_rate_12                         :8;
+  uint8_t symbol_rate_34                         :8;
+  uint8_t symbol_rate_56                         :8;
+#ifdef __BIG_ENDIAN__
+  uint8_t symbol_rate_7                          :4;
+  uint8_t FEC_inner                              :4;
+#else
+  uint8_t FEC_inner                              :4;
+  uint8_t symbol_rate_7                          :4;
+#endif
+} descr_cable_delivery_t;
 
 /***************************************************
  *                ATSC PSIP tables                 *
@@ -859,7 +887,8 @@ typedef struct {
 
   /** If we have threads, the lock on the packet */
   pthread_mutex_t packetmutex;
-}mumudvb_ts_packet_t;
+}
+mumudvb_ts_packet_t;
 
 
 int get_ts_packet(unsigned char *, mumudvb_ts_packet_t *);

--- a/src/ts.h
+++ b/src/ts.h
@@ -899,12 +899,15 @@ struct mumudvb_channel_t;
 void ts_display_pat(char* log_module,unsigned char *buf);
 void ts_display_country_avaibility_descriptor(char* log_module,unsigned char *buf);
 
+void ts_display_nit(char* mod_log_module,unsigned char *buf);
 void ts_display_nit_network_descriptors(char *log_module, unsigned char *buf,int descriptors_loop_len);
 void ts_display_network_name_descriptor(char* log_module, unsigned char *buf);
 void ts_display_multilingual_network_name_descriptor(char* log_module, unsigned char *buf);
+void ts_display_nit_transport_stream_loop(char *mod_log_module, unsigned char *buf, int stream_loop_len);
 void ts_display_service_list_descriptor(char* log_module, unsigned char *buf);
 void ts_display_lcn_descriptor(char* log_module, unsigned char *buf);
 void ts_display_satellite_delivery_system_descriptor(char* log_module, unsigned char *buf);
+void ts_display_cable_delivery_system_descriptor(char *mod_log_module, unsigned char *buf);
 void ts_display_terrestrial_delivery_system_descriptor(char* log_module, unsigned char *buf);
 void ts_display_frequency_list_descriptor(char* log_module, unsigned char* buf);
 


### PR DESCRIPTION
# NIT Rewrite
I would like to propose this feature to MuMuDVB. In my usecase this enables me
to reduce a stream to only a few frequencies, which we forward to our CMTS. 
Several MuMuDVB instances are streaming a frequency, which allows the CMTS to 
establish a reduced stream again. The patching of the frequencies in the NIT is 
only implemented for cable_delivery_system_descriptor. 
An exemplary config for the first instance would be:
```
# --------------- TUNING ----------------
delivery_system=DVBC_ANNEX_AC # DVBC_ANNEX_B
card=0
freq=330000
srate=6900

# ---------- AUTOCONFIGURATION ----------
autoconfiguration=full
autoconf_radios=1

# -------------- NETWORKING -------------
autoconf_ip4=239.192.%card.%number
common_port=10000
multicast_ttl=16
multicast_ipv4=1
multicast_ipv6=0
rtp_header=1

# ------------ SAP ANNOUNCES ------------
# MuMuDVB patched to not include channels without name
sap_default_group=%type
sap_organisation=nw-cable

# ---------- WHOLE TRANSPONDER ----------
new_channel
ip=239.255.0.1
port=10000
pids=8192

# ----------- TABLE REWRITING -----------
# For full autoconf the pat is rewritten which breaks the full transponder
# streaming. As we stream all PIDs for each SID no rewrite is required.
rewrite_pat=0

# send EPG Data only for the current SID (or all for whole transponder)
#rewrite_eit=1
rewrite_eit=0

rewrite_nit=1
# E58-E61 band
freq_patch=0x03300000->0x07700000
freq_patch=0x04500000->0x07780000
freq_patch=0x04660000->0x07860000 # TSID 10000
freq_patch=0x05620000->0x07940000 # TSID 10017
```

The feature implements NIT-rewriting in the way that only given frequencies are kept.
If you agree, I would also replace `void setCRC32(unsigned char *data)` and 
`bool table_needs_update(char *mod_log_module, const int stored_version, unsigned char *buf)` 
in the other modules.

I tested the check for a new nit version with this:
```
From 3758066efe1e89e9b676d518dea0098569fdbb05 Mon Sep 17 00:00:00 2001
From: Johannes Hack <contact@johanneshack.de>
Date: Wed, 15 Jan 2025 18:01:18 +0100
Subject: [PATCH] DBG: test new nit version

---
 src/rewrite_nit.c | 10 ++++++++++
 1 file changed, 10 insertions(+)

diff --git a/src/rewrite_nit.c b/src/rewrite_nit.c
index 54bdb7c..180ede2 100644
--- a/src/rewrite_nit.c
+++ b/src/rewrite_nit.c
@@ -332,6 +332,7 @@ void get_nit_packet(rewrite_parameters_t *rewr_p, int packet_number, int section
 
 int global_packet_number = -1;
 int global_section_number = -1;
+int nit_section_count = 0;
 
 /**
  * @brief Swapping the NIT packet with a patched packet for every channel
@@ -349,7 +350,16 @@ void nit_rewrite_new_global_packet(unsigned char *ts_packet, rewrite_parameters_
 			log_message(log_module, MSG_FLOOD, "NIT not yet valid, we get a new one (current_next_indicator == 0)");
 			return;
 		}
+		nit_section_count++;
+		if (nit_section_count % 100 == 0) {
+			log_message(log_module, MSG_WARN, "NEW!");
+		}
+		nit_t *nit_header = (nit_t *)(ts_packet + NIT_TS_HEADER_LEN + 1);
+		nit_header->version_number += nit_section_count / 100;
+		nit->version_number += nit_section_count / 100;
+
 		if (table_needs_update(log_module, rewrite_vars->nit_version, ts_packet)) {
+			log_message(log_module, MSG_INFO, "New NIT version. Start caching NIT sections.");
 			rewrite_vars->nit_version = nit->version_number;
 			rewrite_vars->full_nit_ok = false;
 
-- 
2.47.0
```